### PR TITLE
feat(governance): allow campaign contributors to vote for a proposal of a campaign

### DIFF
--- a/src/apps/Governance/modules/Create.tsx
+++ b/src/apps/Governance/modules/Create.tsx
@@ -63,7 +63,7 @@ export const Main = () => {
 	const blockNumber = useBlock()
 	const { account, address, signAndNotify } = useWallet()
 	const { bodies, bodyStates, queryMemberships, memberships } = useGameDaoControl()
-	const { campaigns: campaignsList } = useCrowdfunding()
+	const { campaigns: campaignsList, campaignContributors } = useCrowdfunding()
 
 	const navigate = useNavigate()
 	const [loading, setLoading] = useState(false)
@@ -136,9 +136,6 @@ export const Main = () => {
 							value: c,
 						}
 					}) ?? []
-
-				console.log('availableCampaigns', availableCampaigns)
-				console.log('campaigns', campaigns)
 
 				// TODO: only contributed/owned
 				// setCampaigns(availableCampaigns)

--- a/src/apps/Governance/modules/ProposalList.tsx
+++ b/src/apps/Governance/modules/ProposalList.tsx
@@ -14,7 +14,7 @@ export function ProposalList({ setProposalCount }) {
 	const { address } = useWallet()
 	const { proposals } = useGameDaoGovernance()
 	const { memberships, queryMemberships } = useGameDaoControl()
-	const { campaigns } = useCrowdfunding()
+	const { campaigns, campaignContributors, campaignState } = useCrowdfunding()
 
 	const [filteredProposals, setFilteredProposals] = useState([])
 
@@ -34,7 +34,16 @@ export function ProposalList({ setProposalCount }) {
 				case '0':
 					return membershipIds.includes(proposal.context_id)
 				case '3':
-					return membershipIds.includes(campaigns?.[proposal.context_id]?.org ?? null)
+					const campaign = campaigns?.[proposal.context_id]
+					if (campaign?.org) {
+						return (
+							membershipIds.includes(campaign.org) ||
+							(campaignState?.[campaign.id] === '3' &&
+								campaignContributors?.[campaign.id]?.includes(address))
+						)
+					}
+
+					return false
 			}
 
 			console.error(`Invalid proposal type: ${proposal.proposal_type}`, proposal)
@@ -43,7 +52,7 @@ export function ProposalList({ setProposalCount }) {
 
 		setProposalCount(filteredProposals.length)
 		setFilteredProposals(filteredProposals)
-	}, [proposals, memberships])
+	}, [proposals, memberships, campaignContributors])
 
 	return proposals ? (
 		<Paper sx={{ ...bgPlain }}>

--- a/src/apps/Governance/modules/ProposalList.tsx
+++ b/src/apps/Governance/modules/ProposalList.tsx
@@ -27,6 +27,7 @@ export function ProposalList({ setProposalCount }) {
 
 	// Filter proposals by membership of an DAO
 	useEffect(() => {
+		if(!proposals) return
 		const membershipIds = memberships?.[address] ?? []
 
 		const filteredProposals = Object.values(proposals).filter((proposal) => {

--- a/src/apps/GovernanceInfo/modules/ProposalMetadata.tsx
+++ b/src/apps/GovernanceInfo/modules/ProposalMetadata.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux'
 import { blockStateSelector } from 'src/redux/block.slice'
 import { useGameDaoControl } from 'src/hooks/useGameDaoControl'
 import { useGameDaoGovernance } from '../../../hooks/useGameDaoGovernance'
+import { useCrowdfunding } from '../../../hooks/useCrowdfunding'
 
 export function ProposalMetadata({
 	address,
@@ -22,6 +23,7 @@ export function ProposalMetadata({
 	const { bodyMemberState, memberships, queryBodyMemberState, queryMemberships } =
 		useGameDaoControl()
 	const { proposalStates } = useGameDaoGovernance()
+	const { campaignContributors, campaignState } = useCrowdfunding()
 	const [hasVoted, setHasVoted] = useState(false)
 	const [isMemberState, setIsMemberState] = useState(false)
 	const bodyId = body.id
@@ -38,7 +40,13 @@ export function ProposalMetadata({
 			if (address) {
 				queryBodyMemberState(isOrganisation ? bodyId : body?.org, address)
 				const memberships = await queryMemberships(address)
-				setIsMemberState(memberships?.includes(isOrganisation ? bodyId : body?.org))
+				if (isOrganisation) {
+					setIsMemberState(memberships?.includes(bodyId))
+				} else {
+					setIsMemberState(
+						memberships?.includes(body?.org) && campaignState?.[body?.org] === '3'
+					)
+				}
 			}
 
 			setHasVoted(hasVoted)

--- a/src/apps/GovernanceInfo/modules/ProposalMetadata.tsx
+++ b/src/apps/GovernanceInfo/modules/ProposalMetadata.tsx
@@ -11,14 +11,14 @@ import { useGameDaoGovernance } from '../../../hooks/useGameDaoGovernance'
 import { useCrowdfunding } from '../../../hooks/useCrowdfunding'
 
 export function ProposalMetadata({
-	address,
-	body,
-	proposalOwner,
-	proposal,
-	apiProvider,
-	onVoteClicked,
-	isOrganisation,
-}) {
+									 address,
+									 body,
+									 proposalOwner,
+									 proposal,
+									 apiProvider,
+									 onVoteClicked,
+									 isOrganisation,
+								 }) {
 	const blockNumber = useSelector(blockStateSelector)
 	const { bodyMemberState, memberships, queryBodyMemberState, queryMemberships } =
 		useGameDaoControl()
@@ -40,11 +40,12 @@ export function ProposalMetadata({
 			if (address) {
 				queryBodyMemberState(isOrganisation ? bodyId : body?.org, address)
 				const memberships = await queryMemberships(address)
+
 				if (isOrganisation) {
 					setIsMemberState(memberships?.includes(bodyId))
 				} else {
 					setIsMemberState(
-						memberships?.includes(body?.org) && campaignState?.[body?.org] === '3'
+						memberships?.includes(body?.org) || (campaignContributors?.[bodyId]?.includes(address) && campaignState?.[bodyId] === '3'),
 					)
 				}
 			}
@@ -54,59 +55,59 @@ export function ProposalMetadata({
 	}, [address, proposalId])
 
 	return (
-		<Stack flex="1" spacing={3}>
+		<Stack flex='1' spacing={3}>
 			<Box>
 				<Typography>{isOrganisation ? 'Organisation' : 'Campaign'}</Typography>
 				<Link
-					display="block"
+					display='block'
 					component={NavLink}
 					to={
 						isOrganisation ? `/app/organisations/${bodyId}` : `/app/campaigns/${bodyId}`
 					}
 				>
-					<Typography variant="body1">{body.name}</Typography>
+					<Typography variant='body1'>{body.name}</Typography>
 				</Link>
 			</Box>
 			<Box>
 				<Typography>Creator</Typography>
-				<Link display="block" component={'a'} href={`https://sub.id/#/${proposalOwner}`}>
-					<Typography variant="body1">{`${proposalOwner.substr(
+				<Link display='block' component={'a'} href={`https://sub.id/#/${proposalOwner}`}>
+					<Typography variant='body1'>{`${proposalOwner.substr(
 						0,
-						15
+						15,
 					)}...${proposalOwner.substr(proposalOwner.length - 6)}`}</Typography>
 				</Link>
 			</Box>
 			<Box>
 				<Typography>Start</Typography>
-				<Typography display="block" variant="body1">
+				<Typography display='block' variant='body1'>
 					{moment().add(start, 'seconds').format('YYYY-MM-DD HH:mm')}
 				</Typography>
 			</Box>
 			<Box>
 				<Typography>End</Typography>
-				<Typography display="block" variant="body1">
+				<Typography display='block' variant='body1'>
 					{moment().add(expires, 'seconds').format('YYYY-MM-DD HH:mm')}
 				</Typography>
 			</Box>
-			<Box marginTop="auto !important" paddingTop={3}>
+			<Box marginTop='auto !important' paddingTop={3}>
 				<Typography>Vote</Typography>
 				{proposalState !== 1 ? (
-					<Typography display="block" variant="body1">
+					<Typography display='block' variant='body1'>
 						The voting is no longer active.
 					</Typography>
 				) : isMemberState ? (
 					!hasVoted ? (
-						<Stack direction="row" justifyContent="space-between">
+						<Stack direction='row' justifyContent='space-between'>
 							<Button onClick={() => onVoteClicked(false)}>No</Button>
 							<Button onClick={() => onVoteClicked(true)}>Yes</Button>
 						</Stack>
 					) : (
-						<Typography display="block" variant="body1">
+						<Typography display='block' variant='body1'>
 							You have already voted for this proposal.
 						</Typography>
 					)
 				) : (
-					<Typography display="block" variant="body1">
+					<Typography display='block' variant='body1'>
 						You need to be a member in order to vote for this proposal.
 					</Typography>
 				)}

--- a/src/apps/Organisations/modules/Interactions.tsx
+++ b/src/apps/Organisations/modules/Interactions.tsx
@@ -42,7 +42,7 @@ export function Interactions({ data, hideDashboard }) {
 				if (!state) {
 					// TODO: 2075 Do we need error handling here?
 				}
-			}
+			},
 		)
 	}
 
@@ -60,7 +60,7 @@ export function Interactions({ data, hideDashboard }) {
 				if (!state) {
 					// TODO: 2075 Do we need error handling here?
 				}
-			}
+			},
 		)
 	}
 
@@ -78,7 +78,7 @@ export function Interactions({ data, hideDashboard }) {
 				if (!state) {
 					// TODO: 2075 Do we need error handling here?
 				}
-			}
+			},
 		)
 	}
 
@@ -97,8 +97,8 @@ export function Interactions({ data, hideDashboard }) {
 
 	const isAdmin = () => (address === data?.controller ? true : false)
 
-	const actionType = ['join', 'apply', 'leave'][data.access]
-	const actionCallback = [handleJoin, handleApply, handleLeave][data.access]
+	const actionType = ['join', 'apply', 'join'][data.access]
+	const actionCallback = [handleJoin, handleApply, handleJoin][data.access]
 
 	return (
 		<>
@@ -108,7 +108,7 @@ export function Interactions({ data, hideDashboard }) {
 					fullWidth
 					onClick={() => navigate(`/app/organisations/${data.hash}`)}
 					value={data.access}
-					size="small"
+					size='small'
 				>{`Dashboard`}</Button>
 			)}
 			{isMemberState && !isAdmin() && (
@@ -117,7 +117,7 @@ export function Interactions({ data, hideDashboard }) {
 					fullWidth
 					onClick={handleLeave}
 					value={data.access}
-					size="small"
+					size='small'
 				>{`leave`}</Button>
 			)}
 			{!isMemberState && actionType && (
@@ -126,11 +126,12 @@ export function Interactions({ data, hideDashboard }) {
 					fullWidth
 					onClick={actionCallback}
 					value={data.access}
-					size="small"
+					size='small'
 				>{`${actionType}`}</Button>
 			)}
 			{isAdmin() && (
-				<Button variant={'outlined'} fullWidth size="small" onClick={() => {}}>
+				<Button variant={'outlined'} fullWidth size='small' onClick={() => {
+				}}>
 					Admin
 				</Button>
 			)}

--- a/src/hooks/useCrowdfunding.ts
+++ b/src/hooks/useCrowdfunding.ts
@@ -21,6 +21,7 @@ type CrowdfundingState = {
 	campaignBalance: object
 	campaignState: object
 	campaignContributorsCount: object
+	campaignContributors: object
 	updateCampaigns: (hashes: Array<string>) => void
 }
 
@@ -32,6 +33,7 @@ const INITIAL_STATE: CrowdfundingState = {
 	campaignBalance: null,
 	campaignState: null,
 	campaignContributorsCount: null,
+	campaignContributors: null,
 	updateCampaigns: () => {},
 }
 
@@ -167,6 +169,28 @@ async function queryCampaignContributorsCount(
 	return mapping
 }
 
+async function queryCampaignContributors(apiProvider: ApiPromise, hashes: any): Promise<object> {
+	if (!Array.isArray(hashes) || hashes.length === 0) return null
+
+	const [error, data] = await to(
+		apiProvider.query.gameDaoCrowdfunding.campaignContributors.multi(hashes)
+	)
+
+	if (error) {
+		console.error(error)
+		createErrorNotification('Error while querying the gameDaoCrowdfunding campaignContributors')
+		return null
+	}
+
+	const mapping = {}
+	const formatedData = data.map((c) => c.toHuman())
+	hashes.forEach((hash: any, i) => {
+		mapping[hash] = formatedData?.[i] ?? null
+	})
+
+	return mapping
+}
+
 export const useCrowdfunding = () => {
 	const [lastCampaignsCount, setLastCampaignsCount] = useState<number>(null)
 	const [isDataLoading, setIsDataLoading] = useState<boolean>(false)
@@ -186,6 +210,7 @@ export const useCrowdfunding = () => {
 			queryCampaignBalance(apiProvider, hashes),
 			queryCampaignState(apiProvider, hashes),
 			queryCampaignContributorsCount(apiProvider, hashes),
+			queryCampaignContributors(apiProvider, hashes),
 		])
 
 		if (isMountedRef) {
@@ -205,6 +230,10 @@ export const useCrowdfunding = () => {
 				campaignContributorsCount: {
 					...(crowdfundingState.campaignContributorsCount ?? {}),
 					...(data[3] ?? {}),
+				},
+				campaignContributors: {
+					...(crowdfundingState.campaignContributors ?? {}),
+					...(data[4] ?? {}),
 				},
 			})
 		}
@@ -262,6 +291,7 @@ export const useCrowdfunding = () => {
 					queryCampaignBalance(apiProvider, newHashes),
 					queryCampaignState(apiProvider, newHashes),
 					queryCampaignContributorsCount(apiProvider, newHashes),
+					queryCampaignContributors(apiProvider, newHashes),
 				])
 
 				setIsDataLoading(false)
@@ -283,6 +313,10 @@ export const useCrowdfunding = () => {
 						campaignContributorsCount: {
 							...(crowdfundingState.campaignContributorsCount ?? {}),
 							...(data[3] ?? {}),
+						},
+						campaignContributors: {
+							...(crowdfundingState.campaignContributors ?? {}),
+							...(data[4] ?? {}),
 						},
 					})
 				}


### PR DESCRIPTION
Closes #289 

## Proposed changes

Contributors to a Campaign should be able to vote for proposals even if they are not part of the organisation

## Checklist

- [ ] user that has not contributed to campaign should not be allowed to vote on a campaign proposal
- [ ] user that has contributed to campaign should be allowed to vote on a campaign proposal
- [ ] members of the organisations should be able to vote always